### PR TITLE
Add the ability to append_if_missing

### DIFF
--- a/libraries/rc_file.rb
+++ b/libraries/rc_file.rb
@@ -80,6 +80,9 @@ module RcCookbook
 
       action(:append_if_missing) do
         notifying_block do
+          unless new_resource.type == 'bash'
+            raise "You cannot use append_if_missing on non-bash file types!"
+          end
           new_resource.options.each_pair do |key, value|
             append_if_no_line 'append if missing' do
               path new_resource.path

--- a/libraries/rc_file.rb
+++ b/libraries/rc_file.rb
@@ -78,6 +78,17 @@ module RcCookbook
         end
       end
 
+      action(:append_if_missing) do
+        notifying_block do
+          new_resource.options.each_pair do |key, value|
+            append_if_no_line 'append if missing' do
+              path new_resource.path
+              line key + '="' + value + '"'
+            end
+          end
+        end
+      end
+
       action(:delete) do
         notifying_block do
           file new_resource.path do

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,3 +14,4 @@ supports 'aix'
 supports 'solaris'
 
 depends 'poise', '~> 2.2'
+depends 'line', '~> 0.6.3'

--- a/test/spec/libraries/rc_file_spec.rb
+++ b/test/spec/libraries/rc_file_spec.rb
@@ -92,6 +92,27 @@ no_proxy="localhost,127.0.0.1"
 EOH
   end
 
+  context 'runtime configuration for bashrc using append_if_missing' do
+    recipe do
+      rc_file '/etc/skel/bashrc' do
+        options(
+          'http_proxy' => 'http://proxy.corporate.com:80',
+          'https_proxy' => 'http://proxy.corporate.com:443',
+          'ftp_proxy' => 'http://proxy.corporate.com:80',
+          'no_proxy' => 'localhost,127.0.0.1'
+        )
+        action :append_if_missing
+      end
+    end
+
+    it { is_expected.to render_file('/etc/skel/bashrc').with_content(<<-EOH.chomp) }
+http_proxy="http://proxy.corporate.com:80"
+https_proxy="http://proxy.corporate.com:443"
+ftp_proxy="http://proxy.corporate.com:80"
+no_proxy="localhost,127.0.0.1"
+EOH
+  end
+
   context 'runtime configuration for json' do
     recipe do
       rc_file '/etc/skel/berkshelf' do


### PR DESCRIPTION
Note that the unit test suite has problems with this, but I can use the :append_if_missing command with another cookbook.